### PR TITLE
Fixed post link on category page

### DIFF
--- a/source/_layouts/category.blade.php
+++ b/source/_layouts/category.blade.php
@@ -28,7 +28,7 @@
 @foreach ($posts->where('category', $page->getFilename()) as $post)
 <div class="row">
     <div class="col-xs-12">
-        <h3><a href="{{ $post['path'] }}">{{ $post['title'] }}</a></h3>
+        <h3><a href="{{ $post->getPath() }}">{{ $post['title'] }}</a></h3>
         <p class="text-sm">by {{ $post->author }} · {{ $post->dateFormatted() }} · Number {{ $post->number }}</p>
         <p class="p-xs-b-6 border-b">{!! $post->preview(180) !!}...</p>
     </div>


### PR DESCRIPTION
Post links were broken on the category page( collection metadata like path are now accessed using getters).